### PR TITLE
Fix/hck 4587 v7.3.1 alpha 2 protobuf re from ddl error

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -33,7 +33,7 @@ module.exports = {
 			const fileDefinitions = parser.proto().accept(new protoToCollectionsVisitor());
 			if(_.isEmpty(fileDefinitions.messages) && _.isEmpty(fileDefinitions.enums)){
 				const errorObject = {
-					message: `No definitions was found in the file`,
+					message: `No definitions were found in the file`,
 					stack: {},
 				};
 				logger.log('error', errorObject, 'ProtoBuf file Reverse-Engineering Error');

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -31,13 +31,13 @@ module.exports = {
 			parser.removeErrorListeners();
 			parser.addErrorListener(new ExprErrorListener());
 			const fileDefinitions = parser.proto().accept(new protoToCollectionsVisitor());
-			if(_.isEmpty(fileDefinitions.messages)){
+			if(_.isEmpty(fileDefinitions.messages) && _.isEmpty(fileDefinitions.enums)){
 				const errorObject = {
-					message: `No message was found in the file`,
+					message: `No definitions was found in the file`,
 					stack: {},
 				};
 				logger.log('error', errorObject, 'ProtoBuf file Reverse-Engineering Error');
-				callback(errorObject);
+				return callback(errorObject);
 			}
 			const result = convertParsedFileDataToCollections(fileDefinitions, path.basename(data.filePath));
 			callback(null, result, { dbVersion: fileDefinitions.syntaxVersion }, [], 'multipleSchema');

--- a/reverse_engineering/services/converterService.js
+++ b/reverse_engineering/services/converterService.js
@@ -33,6 +33,34 @@ const convertParsedFileDataToCollections = (parsedData, fileName) => {
         .reduce((definitions, def) => (
             { ...definitions, [def.name]: _.omit(def, ['name']) }), {});
     const rootMessage = _.get(parsedData, 'messages', []).find(message => message.name === rootMessageName);
+
+    if (!rootMessage) {
+      return [
+        {
+          doc: {
+            dbName,
+            emptyBucket: true,
+            bucketInfo: {
+              options,
+              package: packageName,
+              imports,
+              schemaType,
+            },
+            entityLevel: {},
+            views: [],
+          },
+        },
+        {
+          doc: {
+            modelDefinitions: JSON.stringify({ definitions: formattedModelDefinitions }),
+            bucketInfo: {},
+            entityLevel: {},
+            views: [],
+          },
+        },
+      ];
+    }
+
     const hackoladeGeneratedDefsNames = getHackoladeGeneratedDefNames(rootMessage);
     const jsonSchema = getJsonSchema(rootMessage, modelDefinitionsNames, formattedModelDefinitions, hackoladeGeneratedDefsNames);
 


### PR DESCRIPTION
- Fixed an issue when data conversion continued even if the reversed file was empty
- Fixed an issue when the converted file does not have messages and tries to convert them into collections. In this case, it is necessary to return only what is available: information about the schema and model definitions, if any.